### PR TITLE
Creating and returning profile in NextAuth API route

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -12,7 +12,6 @@ const Navbar = () => {
   const router = useRouter()
   const { data: session } = useSession();
   const [hideState, setHideState] = useState(true)
-  // console.log('auth session: ', session)
 
   return (
     <LayoutWrapper>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -3,6 +3,9 @@ import { FaUserCircle } from 'react-icons/fa'
 import { useSession } from 'next-auth/react'
 import ProfilePlaceholder from '../assets/profile-placeholder.png'
 import Image from 'next/image'
+import { getServerAuthSession } from '../server/common/get-server-auth-session'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { authOptions } from './api/auth/[...nextauth]'
 
 const profile = () => {
   const { data: session } = useSession()
@@ -94,6 +97,15 @@ const profile = () => {
 
 export default profile
 
-// export const getServerSideProps = async () => {
-//   // get user data (bio, total likes from all itineraries)
+interface IServerProps {
+  req: NextApiRequest
+  res: NextApiResponse
+}
+
+// export const getStaticProps = async ({req, res}: IServerProps) => {
+//   const session = await getServerAuthSession({ req, res });
+
+//   return {
+//     props: {}
+//   }
 // }

--- a/src/pages/trips/index.tsx
+++ b/src/pages/trips/index.tsx
@@ -7,6 +7,7 @@ import { itineraries } from '../../../prisma/seedData'
 import { unstable_getServerSession } from 'next-auth'
 import { authOptions } from '../api/auth/[...nextauth]'
 import { prisma } from '../../server/db/client'
+import { NextApiRequest, NextApiResponse } from 'next'
 
 const trips = (profileWithItineraries: []) => {
     const [toggle, setToggle] = useState(false)
@@ -36,7 +37,12 @@ const trips = (profileWithItineraries: []) => {
 
 export default trips
 
-export const getServerSideProps = async ({req, res}) => {
+interface IServerProps {
+  req: NextApiRequest
+  res: NextApiResponse
+}
+
+export const getServerSideProps = async ({req, res}: IServerProps) => {
   
   const session = await unstable_getServerSession(req, res, authOptions);
 
@@ -70,6 +76,7 @@ export const getServerSideProps = async ({req, res}) => {
   } catch (e) {
     console.error(e);
   }
+
   return { props: JSON.parse(JSON.stringify(profileWithItineraries)) }
   
 }


### PR DESCRIPTION
- Creating and connecting profile on createUser event in NextAuth route
- Fetching profile in NextAuth session callback and adding to the returned session object

The auth session object will now look like this:
![Screenshot 2023-01-18 at 11 04 52 PM](https://user-images.githubusercontent.com/80180474/213378419-f6231244-bb25-46a7-a47d-779fe4a9c2e9.png)

Because we will now have all the profile data ahead of time, we can statically render the profile page with the profile data.
