### PR TITLE
Adding referential action onDelete, creating API route for profile

### DIFF
--- a/prisma/migrations/20230121010624_adding_on_delete_referential_actions/migration.sql
+++ b/prisma/migrations/20230121010624_adding_on_delete_referential_actions/migration.sql
@@ -1,0 +1,29 @@
+-- DropForeignKey
+ALTER TABLE "Activity" DROP CONSTRAINT "Activity_tripDayId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Comment" DROP CONSTRAINT "Comment_itineraryId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Itinerary" DROP CONSTRAINT "Itinerary_profileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TripDay" DROP CONSTRAINT "TripDay_itineraryId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "User" DROP CONSTRAINT "User_profileId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Itinerary" ADD CONSTRAINT "Itinerary_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TripDay" ADD CONSTRAINT "TripDay_itineraryId_fkey" FOREIGN KEY ("itineraryId") REFERENCES "Itinerary"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_itineraryId_fkey" FOREIGN KEY ("itineraryId") REFERENCES "Itinerary"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Activity" ADD CONSTRAINT "Activity_tripDayId_fkey" FOREIGN KEY ("tripDayId") REFERENCES "TripDay"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,7 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
-  profile       Profile?  @relation(fields: [profileId], references: [id])
+  profile       Profile?  @relation(fields: [profileId], references: [id], onDelete: Cascade)
   profileId     Int?      @unique
   // itinerary     Itinerary[]
 }
@@ -97,7 +97,7 @@ model Itinerary {
   destinations String[]
   likes        Int
   public       Boolean
-  profile      Profile?  @relation(fields: [profileId], references: [id])
+  profile      Profile?  @relation(fields: [profileId], references: [id], onDelete: Cascade)
   profileId    Int?
 }
 
@@ -105,7 +105,7 @@ model TripDay {
   id          Int        @id @default(autoincrement())
   date        DateTime
   activities  Activity[]
-  itinerary   Itinerary? @relation(fields: [itineraryId], references: [id])
+  itinerary   Itinerary? @relation(fields: [itineraryId], references: [id], onDelete: Cascade)
   itineraryId Int?
 }
 
@@ -113,7 +113,7 @@ model Comment {
   id          Int        @id @default(autoincrement())
   profile     Profile    @relation(fields: [profileId], references: [id])
   text        String
-  itinerary   Itinerary? @relation(fields: [itineraryId], references: [id])
+  itinerary   Itinerary? @relation(fields: [itineraryId], references: [id], onDelete: Cascade)
   itineraryId Int?
   profileId   Int
 }
@@ -130,6 +130,6 @@ model Activity {
   city        String?
   country     String?
   photo       String?
-  tripDay     TripDay?  @relation(fields: [tripDayId], references: [id])
+  tripDay     TripDay?  @relation(fields: [tripDayId], references: [id], onDelete: Cascade)
   tripDayId   Int?
 }

--- a/src/pages/api/profile.ts
+++ b/src/pages/api/profile.ts
@@ -1,0 +1,54 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { validateRoute } from "../../lib/auth";
+import { prisma } from '../../server/db/client'
+
+export default validateRoute(async function (
+    req: NextApiRequest,
+    res: NextApiResponse,
+  ): Promise<void> {
+  
+    switch (req.method) {
+      case 'PUT':
+        try {
+            const data = await prisma.profile.update({
+                where: { id: req.body.profileId},
+                data: {
+                    bio: req.body.bio,
+                    username: req.body.username,
+                    distanceUnits: req.body.distanceUnits,
+                    dateFormat: req.body.dateFormat,
+                    timeFormat: req.body.timeFormat,
+                    commentsNotification: req.body.commentsNotification,
+                    remindersNotification: req.body.remindersNotification,
+                    collaboratorJoinedNotification: req.body.collaboratorJoinedNotification,
+                },
+            })
+
+            res.status(200).json(data)
+        } catch(e) {
+            console.log(e)
+            res.status(500).json({ error: 'An error occured while updating the data.'})
+        }
+        break
+      case 'DELETE':
+        try {
+            // delete's user, accounts, sessions, itineraries, tripdays, and activities due to onDelete: Cascade referential action in schema
+            await prisma.profile.delete({
+                where: { id: Number(req.query.profileId) }
+            })
+
+            res.status(204).json({ message: "Resource successfully deleted" })
+        } catch (e) {
+            console.log(e)
+            res.status(500).json({ error: 'An error occured trying to delete the account'})
+        }
+        break
+      default:
+        return res.status(501).json({
+            error: {
+            code: 'method_unknown',
+            message: 'This endpoint only responds to PUT, and DELETE',
+            },
+        });
+    }
+})


### PR DESCRIPTION
- Adding referential action on delete to related models so that when a profile is deleted, everything associated with that is as well (User, Accounts, Sessions, Itineraries, TripDays, Activities, and Comments)
- Creating API route for Profile
   - May need to add a GET route in the future for seeing other users profile's